### PR TITLE
Make it so that the scripts run when crond fires.

### DIFF
--- a/app/scripts/pre-exec.d/040-eramba-settings.sh
+++ b/app/scripts/pre-exec.d/040-eramba-settings.sh
@@ -14,14 +14,18 @@ else
 
 	# delete cache
 	cd /app/app/tmp/cache; find . -type f -exec rm -f {};
-
+	
 	# generate a random security key for cron
 	CRON_KEY=$(openssl rand -hex 20)
 	sed -i "s#//define('CRON_SECURITY_KEY'.*#define('CRON_SECURITY_KEY', '"$CRON_KEY"');#" /app/app/Config/settings.php
 
 	# install crontabs
-	echo "curl -o /dev/null https://$ERAMBA_HOSTNAME/cron/hourly/$CRON_KEY" >  /etc/periodic/hourly/eramba.sh
-	echo "curl -o /dev/null https://$ERAMBA_HOSTNAME/cron/daily/$CRON_KEY" >  /etc/periodic/daily/eramba.sh
+	echo -e "#!/bin/bash\ncurl -o /dev/null https://$ERAMBA_HOSTNAME/cron/hourly/$CRON_KEY" >  /etc/periodic/hourly/eramba	
+	echo -e "#!/bin/bash\ncurl -o /dev/null https://$ERAMBA_HOSTNAME/cron/daily/$CRON_KEY" >  /etc/periodic/daily/eramba
+	
+	# make them executable
+	chmod + x /etc/periodic/hourly/eramba	
+	chmod + x /etc/periodic/daily/eramba
 
 	(crontab -l 2>/dev/null; echo "1 1 1 1 * curl -o /dev/null https://$ERAMBA_HOSTNAME/cron/yearly/$CRON_KEY") | crontab -
 fi


### PR DESCRIPTION
Hi there,

Had a bit of an issue getting this set up yesterday, as the `cron` jobs were not firing. 

Initially tried just removing the `.sh` extension from the scripts (See [here](https://bugs.alpinelinux.org/issues/12)), but that didn't have any affect. Ended up needing to add the shebang and make them executable before they would run. 

![image](https://user-images.githubusercontent.com/1998970/59925279-a8549500-942f-11e9-96cc-636e44026756.png)
